### PR TITLE
Removed doc and deps from git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,6 @@
 # If you run "mix test --cover", coverage assets end up here.
 /cover/
 
-# The directory Mix downloads your dependencies sources to.
-/deps/
-
-# Where 3rd-party dependencies like ExDoc output generated docs.
-/doc/
-
 # Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
 


### PR DESCRIPTION
Ao executar o comando docker-compose up, no momento de executar o phoenix, a imagem não encontra a task phx.server que se encontra no diretório /deps/ ao remover ele do gitignore e sincronizar nos ambientes o issue deve ser resolvido para os deus remotos